### PR TITLE
Alteração no "Relatório de Convênios"

### DIFF
--- a/sigi/apps/casas/admin.py
+++ b/sigi/apps/casas/admin.py
@@ -89,9 +89,7 @@ class ConveniosInline(admin.TabularInline):
         (None, {'fields': (
             ('link_sigad', 'status_convenio', 'num_convenio',
              'projeto', 'observacao'),
-            ('data_adesao', 'data_retorno_assinatura', 'data_termo_aceite',
-             'data_pub_diario', 'data_devolucao_via', 'data_postagem_correio'),
-            ('data_devolucao_sem_assinatura', 'data_retorno_sem_assinatura',),
+            ('data_retorno_assinatura', 'data_pub_diario',),
             ('get_anexos',),
             ('link_convenio',),
         )}),
@@ -105,6 +103,7 @@ class ConveniosInline(admin.TabularInline):
     extra = 0
     can_delete = False
     template = 'admin/casas/convenios_inline.html'
+    ordering = ('-data_retorno_assinatura',)
 
     def has_add_permission(self, request):
         return False
@@ -227,6 +226,8 @@ class ServicoInline(admin.TabularInline):
     link_url.short_description = _(u'URL do serviço')
     link_url.allow_tags = True
 
+    ordering = ('-data_alteracao',)
+
 # class PlanoDiretorInline(admin.TabularInline):
 #     model = PlanoDiretor
 
@@ -238,6 +239,8 @@ class OcorrenciaInline(admin.TabularInline):
     max_num = 0
     can_delete = False
     template = 'admin/casas/ocorrencia_inline.html'
+
+    ordering = ('-data_modificacao',)
 
     def link_editar(self, obj):
         if obj.pk is None:

--- a/sigi/apps/casas/admin.py
+++ b/sigi/apps/casas/admin.py
@@ -77,7 +77,9 @@ class FuncionariosInline(admin.StackedInline):
 
     def get_queryset(self, request):
         return (self.model.objects.exclude(
-            cargo='Presidente').exclude(desativado=True)
+            cargo='Presidente').exclude(desativado=True).order_by('-ult_alteracao')
+            .extra(select={'ult_null': 'ult_alteracao is null'}).extra(order_by=['ult_null'])
+            # A função extra foi usada para quando existir um registro com o campo igual a null não aparecer na frente dos mais novos
         )
 
 

--- a/sigi/apps/convenios/admin.py
+++ b/sigi/apps/convenios/admin.py
@@ -51,8 +51,7 @@ class ConvenioAdmin(BaseModelAdmin):
                         'projeto', 'data_sigi',)}
          ),
         (_(u"Acompanhamento no gabinete"),
-         {'fields': ('data_solicitacao', 'data_sigad', 'tipo_solicitacao',
-                     'status', 'acompanha', 'observacao',)}
+         {'fields': ('data_solicitacao', 'data_sigad', 'observacao',)}
         ),
         (_(u"Gestão do convênio"),
          {'fields': ('servico_gestao', 'servidor_gestao',)}
@@ -67,10 +66,9 @@ class ConvenioAdmin(BaseModelAdmin):
     inlines = (AnexosInline,)
     list_display = ('num_convenio', 'casa_legislativa', 'get_uf',
                     'status_convenio', 'link_sigad', 'data_retorno_assinatura',
-                    'duracao', 'projeto', 'status', 'acompanha',)
+                    'duracao', 'projeto',)
     list_display_links = ('num_convenio', 'casa_legislativa',)
-    list_filter = ('status', ('acompanha', AcompanhaFilter),
-                   ('casa_legislativa__gerentes_interlegis',
+    list_filter = (('casa_legislativa__gerentes_interlegis',
                     GerentesInterlegisFilter), 'projeto',
                    'casa_legislativa__tipo', 'conveniada','equipada',
                    'casa_legislativa__municipio__uf',)

--- a/sigi/apps/convenios/migrations/0010_auto_20210819_0833.py
+++ b/sigi/apps/convenios/migrations/0010_auto_20210819_0833.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('convenios', '0009_auto_20210611_0946'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='convenio',
+            name='data_retorno_assinatura',
+            field=models.DateField(help_text='Conv\xeanio firmado.', null=True, verbose_name='data in\xedcio vig\xeancia', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/sigi/apps/convenios/models.py
+++ b/sigi/apps/convenios/models.py
@@ -130,7 +130,7 @@ class Convenio(models.Model):
         blank=True,
     )
     data_retorno_assinatura = models.DateField(
-        _(u'conveniadas'),
+        _(u'data início vigência'),
         null=True,
         blank=True,
         help_text=_(u'Convênio firmado.')

--- a/sigi/apps/convenios/reports.py
+++ b/sigi/apps/convenios/reports.py
@@ -120,19 +120,19 @@ class ConvenioReport(ReportDefault):
             ),
         ]
 
-    groups = [
-        ReportGroup(attribute_name='casa_legislativa.municipio.uf',
-                    band_header=ReportBand(
-                        height=0.7 * cm,
-                        elements=[
-                            ObjectValue(attribute_name='casa_legislativa.municipio.uf',
-                                        get_Value=lambda instance: '%s: %s' % (_(u'Casa Legislativa'), instance.casa_legislativa.uf)
-                                        )
-                        ],
-                        borders={'top': True},
-                    )
-                    )
-    ]
+    #groups = [
+    #    ReportGroup(attribute_name='casa_legislativa.municipio.uf',
+    #                band_header=ReportBand(
+    #                    height=0.7 * cm,
+    #                    elements=[
+    #                        ObjectValue(attribute_name='casa_legislativa.municipio.uf',
+    #                                    get_Value=lambda instance: '%s: %s' % (_(u'Casa Legislativa'), instance.casa_legislativa.uf)
+    #                                    )
+    #                    ],
+    #                    borders={'top': True},
+    #                )
+    #                )
+    #]
 
 
 class ConvenioReportSemAceite(ConvenioReport):

--- a/sigi/apps/convenios/reports.py
+++ b/sigi/apps/convenios/reports.py
@@ -27,7 +27,7 @@ class SemEquipamentosReport(object):
 
 class ConvenioReport(ReportDefault):
     title = _(u'Relatório de Parcerias')
-
+    
     class band_page_header(ReportDefault.band_page_header):
 
         label_top = ReportDefault.band_page_header.label_top
@@ -270,16 +270,16 @@ class ConvenioReportRegiao(ReportDefault):
 
 
 class ConvenioPorCMReport(ConvenioReport):
-    title = _(u'Relatório de Convênios por Câmara Municipal')
+    title = _(u'Relatório de Parcerias por Câmara Municipal')
 
 
 class ConvenioPorALReport(ConvenioReport):
-    title = _(u'Relatório de Convênios por Assembléia Legislativa')
+    title = _(u'Relatório de Parcerias por Assembléia Legislativa')
 
 
 class ConvenioReportSemAceiteCM(ConvenioReportSemAceite):
-    title = _(u'Relatório de Convênios por Câmara Municipal')
+    title = _(u'Relatório de Parcerias por Câmara Municipal')
 
 
 class ConvenioReportSemAceiteAL(ConvenioReportSemAceite):
-    title = _(u'Relatório de Convênios por Assembléia Legislativa')
+    title = _(u'Relatório de Parcerias por Assembléia Legislativa')

--- a/sigi/apps/convenios/reports.py
+++ b/sigi/apps/convenios/reports.py
@@ -26,12 +26,12 @@ class SemEquipamentosReport(object):
 
 
 class ConvenioReport(ReportDefault):
-    title = _(u'Relatório de Convênios')
+    title = _(u'Relatório de Parcerias')
 
     class band_page_header(ReportDefault.band_page_header):
 
         label_top = ReportDefault.band_page_header.label_top
-        label_left = [0, 1.5, 7, 9, 11, 13, 15, 17]
+        label_left = [0, 2.5, 6, 8, 10, 12, 14, 16]
         elements = list(ReportDefault.band_page_header.elements)
         height = 4.7 * cm
 
@@ -47,38 +47,32 @@ class ConvenioReport(ReportDefault):
                 top=label_top + 0.4 * cm,
             ),
             Label(
-                text=_(u"Data de Adesão"),
+                text=_(u"Número do Convênio"),
                 left=label_left[2] * cm,
                 top=label_top,
                 width=2 * cm,
             ),
             Label(
-                text=_(u"Número do Convênio"),
+                text=_(u"Data do Convênio"),
                 left=label_left[3] * cm,
                 top=label_top,
                 width=2 * cm,
             ),
             Label(
-                text=_(u"Data do Convênio"),
+                text=_(u"Data de Publicação"),
                 left=label_left[4] * cm,
                 top=label_top,
                 width=2 * cm,
             ),
             Label(
-                text=_(u"Data de Publicação"),
-                left=label_left[5] * cm,
-                top=label_top,
-                width=2 * cm,
-            ),
-            Label(
-                text=_(u"Data de Aceite"),
-                left=label_left[6] * cm,
-                top=label_top,
-                width=2 * cm,
-            ),
-            Label(
                 text=_(u"Projeto"),
-                left=label_left[7] * cm,
+                left=label_left[5] * cm,
+                top=label_top + 0.4 * cm,
+                width=2 * cm,
+            ),
+            Label(
+                text=_(u"Orgão"),
+                left=label_left[6] * cm,
                 top=label_top + 0.4 * cm,
                 width=2 * cm,
             ),
@@ -89,7 +83,7 @@ class ConvenioReport(ReportDefault):
 
     class band_detail(ReportDefault.band_detail):
 
-        label_left = [0, 1.5, 7, 9, 11, 13, 15, 17]
+        label_left = [0, 2.5, 6, 8, 10, 12, 14, 16]
 
         elements = [
             ObjectValue(
@@ -101,36 +95,28 @@ class ConvenioReport(ReportDefault):
                 left=label_left[1] * cm
             ),
             ObjectValue(
-                attribute_name='data_adesao',
-                left=label_left[2] * cm,
-                get_value=lambda instance:
-                    instance.data_adesao.strftime('%d/%m/%Y') if instance.data_adesao is not None else '-'
-            ),
-            ObjectValue(
                 attribute_name='num_convenio',
-                left=label_left[3] * cm
+                left=label_left[2] * cm
             ),
             ObjectValue(
                 attribute_name='data_retorno_assinatura',
-                left=label_left[4] * cm,
+                left=label_left[3] * cm,
                 get_value=lambda instance:
                     instance.data_retorno_assinatura.strftime('%d/%m/%Y') if instance.data_retorno_assinatura is not None else '-'
             ),
             ObjectValue(
                 attribute_name='data_pub_diario',
-                left=label_left[5] * cm,
+                left=label_left[4] * cm,
                 get_value=lambda instance:
                     instance.data_pub_diario.strftime('%d/%m/%Y') if instance.data_pub_diario is not None else '-'
             ),
             ObjectValue(
-                attribute_name='data_termo_aceite',
-                left=label_left[6] * cm,
-                get_value=lambda instance:
-                    instance.data_termo_aceite.strftime('%d/%m/%Y') if instance.data_termo_aceite is not None else '-'
+                attribute_name='projeto.sigla',
+                left=label_left[5] * cm
             ),
             ObjectValue(
-                attribute_name='projeto.sigla',
-                left=label_left[7] * cm
+                attribute_name='casa_legislativa.nome',
+                left=label_left[6] * cm
             ),
         ]
 
@@ -154,7 +140,7 @@ class ConvenioReportSemAceite(ConvenioReport):
     class band_page_header(ReportDefault.band_page_header):
 
         label_top = ReportDefault.band_page_header.label_top
-        label_left = [0, 1.5, 7, 9, 11, 13, 15, 17]
+        label_left = [0, 2.5, 6, 8, 10, 12, 14, 16]
         elements = list(ReportDefault.band_page_header.elements)
         height = 4.7 * cm
 
@@ -170,32 +156,26 @@ class ConvenioReportSemAceite(ConvenioReport):
                 top=label_top + 0.4 * cm,
             ),
             Label(
-                text=_(u"Data de Adesão"),
-                left=label_left[3] * cm,
-                top=label_top,
-                width=2 * cm,
-            ),
-            Label(
                 text=_(u"Número do Convênio"),
-                left=label_left[4] * cm,
+                left=label_left[2] * cm,
                 top=label_top,
                 width=2 * cm,
             ),
             Label(
                 text=_(u"Data do Convênio"),
-                left=label_left[5] * cm,
+                left=label_left[3] * cm,
                 top=label_top,
                 width=2 * cm,
-            ),
-            Label(
-                text=_(u"Data de Publicação"),
-                left=label_left[6] * cm,
-                top=label_top,
-                width=2 * cm,
-            ),
+            ),            
             Label(
                 text=_(u"Projeto"),
-                left=label_left[7] * cm,
+                left=label_left[4] * cm,
+                top=label_top,
+                width=2 * cm,
+            ),
+            Label(
+                text=_(u"Orgão"),
+                left=label_left[5] * cm,
                 top=label_top + 0.4 * cm,
                 width=2 * cm,
             ),
@@ -203,7 +183,7 @@ class ConvenioReportSemAceite(ConvenioReport):
 
     class band_detail(ReportDefault.band_detail):
 
-        label_left = [0, 1.5, 7, 9, 11, 13, 15, 17]
+        label_left = [0, 2.5, 6, 8, 10, 12, 14, 16]
 
         elements = [
             ObjectValue(
@@ -215,30 +195,22 @@ class ConvenioReportSemAceite(ConvenioReport):
                 left=label_left[1] * cm
             ),
             ObjectValue(
-                attribute_name='data_adesao',
-                left=label_left[3] * cm,
-                get_value=lambda instance:
-                    instance.data_adesao.strftime('%d/%m/%Y') if instance.data_adesao is not None else '-'
-            ),
-            ObjectValue(
                 attribute_name='num_convenio',
-                left=label_left[4] * cm
+                left=label_left[2] * cm
             ),
             ObjectValue(
                 attribute_name='data_retorno_assinatura',
-                left=label_left[5] * cm,
+                left=label_left[3] * cm,
                 get_value=lambda instance:
                     instance.data_retorno_assinatura.strftime('%d/%m/%Y') if instance.data_retorno_assinatura is not None else '-'
             ),
             ObjectValue(
-                attribute_name='data_pub_diario',
-                left=label_left[6] * cm,
-                get_value=lambda instance:
-                    instance.data_pub_diario.strftime('%d/%m/%Y') if instance.data_pub_diario is not None else '-'
+                attribute_name='projeto.sigla',
+                left=label_left[4],
             ),
             ObjectValue(
-                attribute_name='projeto.sigla',
-                left=label_left[7] * cm
+                attribute_name='casa_legislativa.nome',
+                left=label_left[5] * cm
             ),
         ]
 
@@ -247,7 +219,7 @@ float_duas_casas = lambda instance: '%.2f' % (instance)
 
 
 class ConvenioReportRegiao(ReportDefault):
-    title = _(u'Relatório de Convênios por Região')
+    title = _(u'Relatório de Parcerias por Região')
 
     class band_page_header(ReportDefault.band_page_header):
         label_top = ReportDefault.band_page_header.label_top

--- a/sigi/apps/convenios/views.py
+++ b/sigi/apps/convenios/views.py
@@ -86,6 +86,8 @@ def carrinhoOrGet_for_qs(request):
     if 'carrinho_convenios' in request.session:
         ids = request.session['carrinho_convenios']
         qs = Convenio.objects.filter(pk__in=ids)
+        qs = qs.order_by("casa_legislativa__municipio__uf", "casa_legislativa__municipio")
+        qs = get_for_qs(request.GET, qs)
     else:
         qs = Convenio.objects.all()
         if request.GET:

--- a/sigi/apps/ocorrencias/admin.py
+++ b/sigi/apps/ocorrencias/admin.py
@@ -85,13 +85,13 @@ class OcorrenciaAdmin(BaseModelAdmin):
     def get_changelist(self, request, **kwargs):
         return OcorrenciaChangeList
 
-    def get_readonly_fields(self, request, obj=None):
-        fields = list(self.readonly_fields)
-        if obj is not None:
-            fields.extend(['casa_legislativa', 'categoria', 'tipo_contato', 'assunto', 'status', 'descricao', ])
-            if obj.status in [Ocorrencia.STATUS_RESOLVIDO, Ocorrencia.STATUS_FECHADO, Ocorrencia.STATUS_DUPLICADO]:  # Fechados
-                fields.append('prioridade')
-        return fields
+    # def get_readonly_fields(self, request, obj=None):
+    #    fields = list(self.readonly_fields)
+    #    if obj is not None:
+    #        fields.extend(['casa_legislativa', 'categoria', 'tipo_contato', 'assunto', 'status', 'descricao', ])
+    #        if obj.status in [Ocorrencia.STATUS_RESOLVIDO, Ocorrencia.STATUS_FECHADO, Ocorrencia.STATUS_DUPLICADO]:  # Fechados
+    #            fields.append('prioridade')
+    #    return fields
 
     def get_fieldsets(self, request, obj=None):
         if obj is None:


### PR DESCRIPTION
Alterações no documento "Relatório de Convenios".
O documento sofreu as seguintes alterações:

- O titúlo passa a ser "Relatório de parcerias";
- Foi adicionado o campo Orgão (nome do Orgão);
- Não são mais agrupados os convenios por estados;
- Não são mais mostrados os nomes completos das UFs, agora somente a sigla é mostrada;
- Agora o documento é ordenado por UF, Municipio;
- Foram retirados os campos: DataAdesao e DataAceite;