### PR TITLE
Ajustes no template de exportação do Admin com Bootstrap e resolução de conflitos de merge

### DIFF
--- a/sigi/templates/admin/import_export/base.html
+++ b/sigi/templates/admin/import_export/base.html
@@ -1,0 +1,23 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_modify %}
+{% load admin_urls %}
+{% load static %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
+
+{% if not is_popup %}
+  {% block nav-breadcrumbs %}
+    <nav aria-label="{% translate 'Breadcrumbs' %}">
+      {% block breadcrumbs %}
+        <div class="breadcrumbs">
+          <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+          &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+          &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+          &rsaquo; {% block breadcrumbs_last %}{% endblock %}
+        </div>
+      {% endblock %}
+    </nav>
+  {% endblock %}
+{% endif %}
+
+{% block bodyclass %}{{ block.super }} {{ opts.app_label }}-{{ opts.object_name.lower }} change-form{% endblock %}

--- a/sigi/templates/admin/import_export/export.html
+++ b/sigi/templates/admin/import_export/export.html
@@ -1,0 +1,80 @@
+{% extends "admin/import_export/base.html" %}
+{% load i18n %}
+{% load admin_urls %}
+{% load import_export_tags %}
+
+{% block extrahead %}
+{{ block.super }}
+<script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
+{{ form.media }}
+{% endblock %}
+
+{% block breadcrumbs_last %}
+{% translate "Export" %}
+{% endblock %}
+
+{% block content %}
+{% if form.errors %}
+  {{ form.errors }}
+{% endif %}
+<form action="{{ export_url }}" method="POST">
+  {% csrf_token %}
+  {# Export request has originated from an Admin UI action #}
+  {% if form.initial.export_items %}
+    <p>
+    {% blocktranslate count len=form.initial.export_items|length %}
+      Export {{ len }} selected item.
+      {% plural %}
+      Export {{ len }} selected items.
+    {% endblocktranslate %}
+    </p>
+  {% endif %}
+
+  {# Fields list is not required with selectable fields form #}
+  {% if not form.is_selectable_fields_form %}
+    {% include "admin/import_export/resource_fields_list.html" with import_or_export="export" %}
+  {% endif %}
+  <p></p>
+
+  <fieldset class="module">
+    <p style="padding: 0;">{% translate "This exporter will export the following fields:" %}</p>
+    
+    <div class="row">
+      {% for field in form.visible_fields %}
+        {% if field.name != "format" %} {# Excluindo o campo "Formato" da lista automática #}
+          <div class="col-md-4 col-lg-3 mb-4">
+            <div class="card h-100" style="width: 100%;">
+              <div class="card-body">
+                <label for="{{ field.id_for_label }}" class="form-label d-block">
+                  {{ field.label }}
+                </label>
+                {{ field }}
+                {% if field.field.help_text %}
+                  <small class="text-muted d-block mt-1">
+                    {{ field.field.help_text|safe }}
+                  </small>
+                {% endif %}
+              </div>
+            </div>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
+  
+    {% for field in form.hidden_fields %}
+      {{ field }}
+    {% endfor %}
+  </fieldset>
+  
+  {# Campo "Formato" separado, posicionado de forma independente #}
+  <div class="mt-4">
+    <label for="{{ form.format.id_for_label }}" class="form-label">{{ form.format.label }}</label>
+    {{ form.format }}
+  </div>
+  
+  <div class="submit-row mt-4">
+    <input type="submit" class="btn btn-outline-primary" value="{% translate "Submit" %}">
+  </div>
+  
+</form>
+{% endblock %}


### PR DESCRIPTION
Este PR implementa os ajustes necessários no template da tela de exportação de dados para adequá-lo ao padrão visual do Bootstrap, conforme solicitado, além de resolver conflitos de merge com base no PR anterior (#183).  

### Alterações realizadas:  
1. **Adicionado novo template base:**  
   - Criado o arquivo `base.html` em `sigi/templates/admin/import_export/`, sobrescrevendo o bloco `nav-breadcrumbs` do Admin para corrigir a duplicação do link "Início" no breadcrumb.  

2. **Correções no template de exportação:**  
   - Criado o arquivo `export.html` para ajustar o layout dos checkboxes, labels e campos de formulário:  
     - Alinhamento correto dos checkboxes e labels.  
     - Inclusão de classes do Bootstrap para o botão de envio (`btn btn-outline-primary`).  

3. **Estilização e formatação:**  
   - Adicionado estilo consistente aos elementos do formulário, como alinhamento utilizando `d-flex` e margens para melhorar a apresentação.  

4. **Resolução de conflitos:**  
   - Ajustes realizados para integrar as mudanças presentes no PR anterior (#183) e garantir consistência na base de código.  

### Antes e depois  
   - **Antes:**  
   
![image](https://github.com/user-attachments/assets/f92d623b-9111-48b1-a721-228f52b9d315)

   - **Depois:**  

![image](https://github.com/user-attachments/assets/f6db7865-5fe9-4482-ae07-cd572c9f791c)

### Como testar:  
1. Acesse o SIGI e navegue até **Agenda de Espaços > Reservas**.  
2. Clique no botão "Export all" na barra de ferramentas.  
3. Verifique os seguintes pontos:  
   - O breadcrumb deve exibir corretamente os links sem duplicação.  
   - Labels e checkboxes devem estar alinhados.  
   - O botão de envio deve estar estilizado de acordo com o Bootstrap.  

Aguardo a revisão. Caso haja algo a ajustar, fico à disposição!  